### PR TITLE
Fix capture start/stop calls

### DIFF
--- a/pytest_cassandra.py
+++ b/pytest_cassandra.py
@@ -373,7 +373,7 @@ class CCMCluster(object):
         name = tempfile.mkdtemp(suffix='-cassandra').split('/')[-1]
         if self.pluginmanager:
             capmanager = self.pluginmanager.getplugin('capturemanager')
-            capmanager.suspendcapture()
+            capmanager.suspend_global_capture()
         else:
             capmanager = None
         try:
@@ -382,7 +382,7 @@ class CCMCluster(object):
             logger.info("Cassandra cluster setup complete")
         finally:
             if capmanager:
-                capmanager.resumecapture()
+                capmanager.resume_global_capture()
         return self
 
     def __exit__(self, *args, **kwargs):


### PR DESCRIPTION
In more recent versions of pytest, the `capturemanager` plugin's `suspendcapture` and `resumecapture` have been renamed to `suspend_global_capture` and `resume_global_capture`.
References:
- https://github.com/pytest-dev/pytest/commit/22f338d74d19e188a5a88a51cc722b771b07c24c
- https://stackoverflow.com/questions/50638571/in-pytest-how-to-config-capturemanager-plugin-error-capturemanager-object-has/50641035#50641035